### PR TITLE
feat(homepage) "featured posts" implementation

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -305,10 +305,10 @@
         hits
           .map(transformer)
           .sort((hit1, hit2) => {
-            const i1 = featured.indexOf(hit1.path);
+            const i1 = featured.indexOf(`/${hit1.path}`);
             if (i1 !== -1) {
               // hit1 is a featured post, now check hit2
-              const i2 = featured.indexOf(hit2.path);
+              const i2 = featured.indexOf(`/${hit2.path}`);
               if (i2 !== -1) {
                 // hit2 is also a featured post:
                 //   move hit1 up if i2 is greater than i1
@@ -329,7 +329,6 @@
             $hit.appendChild($item);
             $list.appendChild($hit);
           });
-        // featurePosts();
       }
     });
   }
@@ -345,28 +344,6 @@
     }
     return featured;
   }
-
-  function featurePosts() {
-    const featured=getFeaturedPostsPaths();
-    const $list=document.querySelector('.ais-Hits-list');
-    const $hits=$list.children;
-    let $newhits;
-    const allHrefs=[];
-    $list.querySelectorAll('.ais-Hits-item .hero a:first-of-type').forEach((e) => allHrefs.push(e.getAttribute('href')));
-
-    $newhits=featured.map((e) => {
-      const i=allHrefs.indexOf(e);
-      return ($hits[i].cloneNode(true));
-    });
-    allHrefs.forEach((e, i) => {
-      if (featured.indexOf(e)<0) {
-        $newhits.push($hits[i].cloneNode(true));
-      }
-    })
-    $list.innerHTML='';
-    $newhits.forEach((e) => $list.appendChild(e));
-  }
-
 
   /*
    * homepage

--- a/scripts.js
+++ b/scripts.js
@@ -254,8 +254,12 @@
         },
         body: JSON.stringify({ requests }),
       });
-      const { results: [{ hits: featured }, { hits: newest }] } = await res.json();
-      return { hits: featured.concat(newest).slice(0, hitsPerPage) };
+      const { results: [{ hits: featured }, { hits: latest }] } = await res.json();
+      const hits = featured.concat(latest).reduce((unique, hit) => {
+        return unique.find((item) => item.objectID === hit.objectID)
+          ? unique : [...unique, hit];
+      }, []);
+      return { hits: hits.slice(0, hitsPerPage) };
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -724,6 +724,10 @@ main div.topics {
 
 }
 
+.hidden {
+  display: none;
+}
+
 @media (min-width:900px) {
   .default {
     margin: auto;


### PR DESCRIPTION
as described in #155 we would like to influence the order of posts on homepages.
this implementation provides a "pinning" mechanism that keeps a list of explicit posts that are a section with a heading `Featured  Posts` at the top of the search result overriding the default "most recent" order.

here are a couple of things that still need to get done:

- [ ] limit the number of results back to the original 12/13
- [ ] bring back the homepage transformer for a the different resolution for the first post
- [ ] impl/test for author and topic pages

more generally, we should probably eventually rewrite this to (a) not work on dom manipulations for deduping and sorting or (b) even better do this in one query as opposed to two queries.
