### PR TITLE
fix(index): provide external path in index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -44,6 +44,10 @@ indices:
         value: |
           attribute(el, 'content')
         faceted: true
+      external-path:
+        select: none
+        value: |
+          replace(path, '/publish/', '/')
     queries:
       recent:
         query: "*"


### PR DESCRIPTION
fix #169 

Adds a property `external-path` that contains the path to a document (without leading slash), where `/publish/` in the document path has been stripped.

Depends on fix to issue: https://github.com/adobe/helix-index-pipelines/issues/199

Verifying on this branch, a request to index:
```
en/publish/creating-adobe-experience-platform-pipeline-with-kafka.html
```
will lead to the following indexed property:
```
"external-path": "en/creating-adobe-experience-platform-pipeline-with-kafka.html"
```