### PR TITLE
refactor(scripts): add body class based on page type detected in url

### DIFF
--- a/helix-markup.yaml
+++ b/helix-markup.yaml
@@ -1,0 +1,23 @@
+version: 1
+
+markup:
+  home:
+    match: /(|:lang/home)(.*)
+    classnames: home-page
+    type: url
+  author:
+    match: /:lang/author(.*)
+    classnames: author-page
+    type: url
+  post:
+    match: /:lang/(post|drafts/|publish/|\d{4}\/\d{2}\/\d{2}/)(.*)
+    classnames: post-page
+    type: url
+  product:
+    match: /:lang/product(.*)
+    classnames: product-page
+    type: url
+  topic:
+    match: /:lang/topic(.*)
+    classnames: topic-page
+    type: url

--- a/scripts.js
+++ b/scripts.js
@@ -48,6 +48,25 @@ function getOtDomainId() {
   return `${domains[currentDomain] || domains[Object.keys(domains)[0]]}-test`;
 };
 
+/**
+ * Return the language detected in the current path
+ */
+function getDetectedLanguage() {
+  return window.location.pathname
+    .split('/').slice(1, 2)
+    .pop();
+}
+
+/**
+ * Return the page type detected in the current markup
+ */
+function getDetectedPageType() {
+  return [...document.documentElement.classList]
+    .filter((cls) => cls.endsWith('-page'))
+    .map((cls) => cls.split('-')[0])
+    .pop();
+}
+
 // Prep images for lazy loading and use adequate sizes
 const imgWidth = window.innerWidth === 375 ? 750 : // double size for retina
               window.innerWidth < 900 ? 900 : 2048;
@@ -91,35 +110,8 @@ window.blog = function() {
     FR: 'fr',
   };
   const context = '/';
-  let language = LANG.EN;
-  let pageType = TYPE.HOME;
-  const segs = window.location.pathname
-    .split('/')
-    .filter(seg => seg !== '');
-  if (segs.length > 0) {
-    if (segs.length >= 1) {
-      // language
-      for (let [key, value] of Object.entries(LANG)) {
-        if (value === segs[0]) {
-          language = value;
-          break;
-        }
-      }
-    }
-    if (segs.length >= 2) {
-      // post pages
-      if (segs[1] === 'drafts' || segs[1] === 'publish' || segs[1] === 'documentation' || /\d{4}\/\d{2}\/\d{2}/.test(segs.join('/'))) {
-        pageType = TYPE.POST;
-      } else {
-        for (let [key, value] of Object.entries(TYPE)) {
-          if (segs[1].startsWith(value)) {
-            pageType = value;
-            break;
-          }
-        }
-      }
-    }
-  }
+  const language = LANG[getDetectedLanguage().toUpperCase()] || LANG.EN;
+  const pageType = TYPE[getDetectedPageType().toUpperCase()] || TYPE.HOME;
   return { context, language, pageType, TYPE, LANG };
 }();
 

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -34,13 +34,6 @@ export function createTag(name, attrs) {
 }
 
 /**
- * Adds page type as body class.
- */
-export function addPageTypeAsBodyClass() {
-  document.body.classList.add(`${window.blog.pageType}-page`);
-}
-
-/**
  * Wraps nodes with a new parent node.
  * @param {node} newparent The new parent node
  * @param {array} nodes The nodes to wrap
@@ -401,5 +394,4 @@ export function applyFilters(products) {
 
 window.addEventListener('load', function() {
   removeHeaderAndFooter();
-  addPageTypeAsBodyClass();
 });


### PR DESCRIPTION
Use helix markup to inject the class on the html node so it can be read
from the scripts file and we can remove some of the JS logic.

Requires: adobe/helix-pages#382

fix #241