### PR TITLE
feat(design): consolidate heading top margin and disable launch

### DIFF
--- a/head.html
+++ b/head.html
@@ -31,4 +31,4 @@
 <script src="/scripts/common.js" type="module"></script>
 <script async src="https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js" id="feds-script"></script>
 <script async src="https://static.adobelogin.com/imslib/imslib.min.js"></script>
-<script async src="//assets.adobedtm.com/faa4be0eccc5/eb6d7e040b1b/launch-1e5aae35cdd5-development.min.js"></script>
+<!-- script async src="//assets.adobedtm.com/faa4be0eccc5/eb6d7e040b1b/launch-1e5aae35cdd5-development.min.js"></script -->

--- a/style/post.css
+++ b/style/post.css
@@ -237,9 +237,17 @@
   line-height: 1.3em;
 }
 
-.post-page main>div.post-body p+h2, .post-page main>div.post-body div+h2,
-.post-page main>div.post-body p+h3 {
+.post-page main>div.post-body *+h2 {
   margin-top: 64px;
+}
+
+.post-page main>div.post-body *+h3 {
+  margin-top: 48px;
+}
+
+.post-page main>div.post-body h1+h2,
+.post-page main>div.post-body h2+h3 {
+  margin-top: 32px;
 }
 
 .post-page .products a {


### PR DESCRIPTION
Fix #272 

Headings 2 and 3 look more balanced in different settings now.