### PR TITLE
fix(index): do not index teaser if no body

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -34,7 +34,7 @@ indices:
         value: |
           attribute(el, 'src')
       teaser:
-        select: main > div:nth-child(n+4) p
+        select: main > div:nth-child(n+4):not(:last-child) p
         value: |
           words(textContent(el), 0, 20)
       sourceHash:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,12 +1,12 @@
 version: 1
 
 indices:
-  blog-posts-new:
+  raw_index:
     source: html
     fetch: https://{repo}-{owner}.project-helix.page/{path}
     include:
       - (en|de|fr)/publish/**/*.(md|docx)
-    target: azure
+    target: https://adobe.sharepoint.com/:x:/r/sites/TheBlog/Shared%20Documents/theblog/en/query-index.xlsx?d=we7bf6b3af3234076968b30a1565f2373&csf=1&web=1&e=q9o8tW
     sitemap: en/query-index.json
     properties:
       author:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,12 +1,12 @@
 version: 1
 
 indices:
-  raw_index:
+  blog-posts-new:
     source: html
     fetch: https://{repo}-{owner}.project-helix.page/{path}
     include:
       - (en|de|fr)/publish/**/*.(md|docx)
-    target: https://adobe.sharepoint.com/:x:/r/sites/TheBlog/Shared%20Documents/theblog/en/query-index.xlsx?d=we7bf6b3af3234076968b30a1565f2373&csf=1&web=1&e=q9o8tW
+    target: azure
     sitemap: en/query-index.json
     properties:
       author:


### PR DESCRIPTION
When no post body, the topics and categories get indexed as teaser which is incorrect. teaser should be empty.