### PR TITLE
Allow the section containing the author to be in either case

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -12,7 +12,7 @@ indices:
       author:
         select: main > div:nth-of-type(3) > p:nth-of-type(1)
         value: |
-          match(el, 'by (.*)')
+          match(el, '[bB]y (.*)')
       title:
         select: main > div > h1:first-of-type
         value: |

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -5,7 +5,7 @@ indices:
     source: html
     fetch: https://{repo}-{owner}.project-helix.page/{path}
     include:
-      - (en|de|fr)/publish/**/*.(md|docx)
+      - (en|de|fr)/publish/*/*/*/*.(md|docx)
     target: https://adobe.sharepoint.com/:x:/r/sites/TheBlog/Shared%20Documents/theblog/en/query-index.xlsx?d=we7bf6b3af3234076968b30a1565f2373&csf=1&web=1&e=q9o8tW
     sitemap: en/query-index.json
     properties:


### PR DESCRIPTION
fix #349 

At the same time, only index files that lie in `.../publish/YYYY/MM/DD/...`.