### PR TITLE
fix(tagger): indexer expects topics before products

### DIFF
--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -246,7 +246,7 @@
       }
 
       var copybuffer = document.getElementById('copybuffer');
-      copybuffer.value = `---\r\n\r\nProducts: ${products}\r\nTopics: ${topics}\r\n\r\n`
+      copybuffer.value = `---\r\n\r\nTopics: ${topics}\r\nProducts: ${products}\r\n\r\n`
 
       document.querySelectorAll('#results>span').forEach((e) => {
         if (selected.indexOf(e.getAttribute('data-target')) < 0) {


### PR DESCRIPTION
Looks like the order changed accidentally at some point, which led the indexer to list topics under products if the products list was empty.