### PR TITLE
Card focus indicators

### DIFF
--- a/.model/homepage.css
+++ b/.model/homepage.css
@@ -54,9 +54,9 @@
 
   .featured.card {
     margin: 40px auto 0 auto;
-    padding-left: 32px;
-    padding-right: 32px;
-    max-width: 1200px;
+    padding-left: 0;
+    padding-right: 0;
+    max-width: 1136px;
   }
 
   main .news-box .content,

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -223,12 +223,12 @@ export function addCard(hit, $container) {
   const $item = createTag('div', {'class': 'card'});
   $item.innerHTML = `
   <div class="hero">
-    <a href="/${hit.path}" title="${hit.title}"><img class="lazyload" src="#" data-src="${hit.hero}" alt="${hit.title}"></a>
+    <a href="/${hit.path}" title="${hit.title}" tabindex="-1"><img class="lazyload" src="#" data-src="${hit.hero}" alt="${hit.title}"></a>
   </div>
   <div class="content">
     <p class="topic"><a href="${hit.topicUrl}" title="${hit.topic}">${hit.topic}</a></p>
     <h2><a href="/${hit.path}" title="${hit.title}">${hit.title}</a></h2>
-    <p class="teaser"><a href="/${hit.path}" title="${hit.teaser}…">${hit.teaser}…</a></p>
+    <p class="teaser"><a href="/${hit.path}" title="${hit.teaser}" tabindex="-1">${hit.teaser}</a></p>
     <p class="date">${hit.date}</p>
   </div>`;
   $container.appendChild($item);

--- a/style.css
+++ b/style.css
@@ -297,6 +297,10 @@
    animation: appear 800ms;
  }
  
+ .card:focus-within {
+   box-shadow: #1473e6 0 0 0 2px;
+ }
+ 
  .card .hero {
    width: 100%;
    padding-bottom: 66.67%; /* 3:2 aspect ratio */

--- a/style.css
+++ b/style.css
@@ -298,7 +298,7 @@
  }
  
  .card:focus-within {
-   box-shadow: 0 0 5px 0 #707070
+   box-shadow: 0 0 0 2px #505050;
  }
  
  .card .hero {

--- a/style.css
+++ b/style.css
@@ -298,7 +298,7 @@
  }
  
  .card:focus-within {
-   box-shadow: #1473e6 0 0 0 2px;
+   box-shadow: 0 0 5px 0 #707070
  }
  
  .card .hero {
@@ -337,11 +337,6 @@
    visibility: hidden;
  }
  
- .card .hero a:focus img {
-   outline: #bcbcbc solid 2px;
-   z-index: 1;
- }
-
  .card .hero a {
    font-size: 0;
  }

--- a/style/home.css
+++ b/style/home.css
@@ -256,6 +256,7 @@
 
   .home-page .featured.card {
     margin: 40px auto 0 auto;
+    border-radius: 0;
     max-width: 1136px;
   }
 

--- a/style/home.css
+++ b/style/home.css
@@ -256,9 +256,7 @@
 
   .home-page .featured.card {
     margin: 40px auto 0 auto;
-    padding-left: 32px;
-    padding-right: 32px;
-    max-width: 1200px;
+    max-width: 1136px;
   }
 
   .home-page .featured.card .hero {


### PR DESCRIPTION
Fix #360 

URL: https://card-focus--theblog--adobe.hlx.page/

@yalagand I tried implementing your feedback: each card has a border while the focus is within, and only topic and title have tabstops.

I couldn't figure out how to change the order so the title would be the first tabstop within the card, but maybe it would be counter-intuitive anyway...