### PR TITLE
Exclude documents from the index that are named 'Document.*'

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -6,6 +6,8 @@ indices:
     fetch: https://{repo}-{owner}.project-helix.page/{path}
     include:
       - (en|de|fr)/publish/*/*/*/*.(md|docx)
+    exclude:
+      - \**/Document.*
     target: https://adobe.sharepoint.com/:x:/r/sites/TheBlog/Shared%20Documents/theblog/en/query-index.xlsx?d=we7bf6b3af3234076968b30a1565f2373&csf=1&web=1&e=q9o8tW
     sitemap: en/query-index.json
     properties:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,7 +7,7 @@ indices:
     include:
       - (en|de|fr)/publish/*/*/*/*.(md|docx)
     exclude:
-      - \**/Document.*
+      - '**/Document.*'
     target: https://adobe.sharepoint.com/:x:/r/sites/TheBlog/Shared%20Documents/theblog/en/query-index.xlsx?d=we7bf6b3af3234076968b30a1565f2373&csf=1&web=1&e=q9o8tW
     sitemap: en/query-index.json
     properties:


### PR DESCRIPTION
fix #402 