### PR TITLE
feat(feed): set up redirect for wordpress feed URLs

### DIFF
--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,5 +1,5 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
-  - from: .*\/feed\/+$
+  - from: .*\/feed\/*$
     to: /feed.xml
     type: temporary

--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,5 +1,5 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
-  - from: .*\/feed(\/)*$
+  - from: .*\/feed/*$
     to: /feed.xml
     type: temporary

--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,5 +1,8 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
-  - from: .*\/feed/*$
+  - from: .*\/feed/$
+    to: /feed.xml
+    type: temporary
+  - from: .*\/feed$
     to: /feed.xml
     type: temporary

--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,2 +1,5 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
+  - from: .*\/feed\/+$
+    to: /feed.xml
+    type: temporary

--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,5 +1,5 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
-  - from: .*\/feed\/*$
+  - from: .*\/feed\/*
     to: /feed.xml
     type: temporary

--- a/helix-redirects.yaml
+++ b/helix-redirects.yaml
@@ -1,5 +1,5 @@
 redirects:
   - https://adobe.sharepoint.com/:x:/s/TheBlog/EaikC7JAUNpAoZy604FUP7YB2oTdxZVtrWNihbJ6k-BCnA?email=&e=Nd2OF4
-  - from: .*\/feed\/*
+  - from: .*\/feed(\/)*$
     to: /feed.xml
     type: temporary


### PR DESCRIPTION
We are seeing quite a few requests to legacy feed URLs which all 404 now. Let's redirect them to the main feed instead.