### PR TITLE
feat(post): optimize image widths

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -121,8 +121,7 @@ function getOtDomainId() {
 };
 
 // Prep images for lazy loading and use adequate sizes
-const imgWidth = window.innerWidth === 375 ? 750 : // double size for retina
-              window.innerWidth < 900 ? 900 : 2048;
+const imgWidth = (window.innerWidth < 1000 ? window.innerWidth : 1000) * window.devicePixelRatio;
 let imgCount = 0;
 
 const observer = new MutationObserver(mutations => {


### PR DESCRIPTION
Loosely related to #219: in the new article design, images are never wider than 1000px anymore, so defaulting to 2048 in most cases seems overkill. This makes it dependent on the `window.innerWidth` and `window.devicePixelRatio` to load the optimal image for all viewports.