### PR TITLE
fix(styles): restore margins

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,7 +31,19 @@
    font-size: 1.125rem;
    line-height: 1.5em;
  }
- 
+
+main > div {
+  padding: 1rem 2rem;
+}
+
+img {
+  width: 100%;
+}
+
+main > div img {
+  max-width: 100%;
+}
+
  h1, h2, h3, h4, h5, h6 {
    font-weight: 600;
    line-height: 1.25em;


### PR DESCRIPTION
Fix #448 

Restore the "default" styles but without the `.default` class.