### PR TITLE
fix(filters): correctly combine main topic with user filters

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -324,6 +324,20 @@ function addArticlesToDeck(hits, omitEmpty, transformer, hasMore, setFocus) {
     }
 }
 
+/**
+ * Check for matches between base topics and topics to match.
+ * The topics to match will be lowercased before matching.
+ * @param {array} baseTopics The base topics
+ * @param {array} topicsToMatch The topics to match
+ * @return {boolean} <code>true</code> if there are matching topics,
+ * else <code>false</code>
+ */
+function matchTopics(baseTopics, topicsToMatch) {
+  return topicsToMatch.filter((t) => {
+    return baseTopics.includes(t.toLowerCase());
+  }).length > 0;
+}
+
 async function translateTable(pages, index) {
   const taxonomy = await getTaxonomy();
   pages.forEach((e) => {
@@ -403,38 +417,34 @@ async function fetchHits(filters, limit, cursor) {
   let i=cursor;
   if (!filters.pathsOnly) {
     for (;i<articles.length;i++) {
-      const e=articles[i];
-      let matched=true;
+      const e = articles[i];
+      const articleTopics = Array.isArray(e.topics) ? e.topics.map(t => t.toLowerCase()) : [];
+      let matched = true;
+
+      if (filters.author && (e.author!=filters.author)) {
+        matched = false;
+      }
+
       if (filters.topics) {
         filters.topics = Array.isArray(filters.topics) ? filters.topics : [filters.topics];
-        // find intersection between filter.topics and current e.topics
-        const matchedTopics = filters.topics.filter((t) => {
-          // quick fix to get caseless comparison working with minimum impact
-          // should be rewritten more efficiently
-          const ltopics=e.topics.map(item => item.toLowerCase())
-          const lt=t.toLowerCase();
-          if(ltopics.includes(lt) || e.products.includes(t.replace('Adobe ', ''))) return true;
-          else return false;
-        });
-        // main topic (or child topics) must match
-        if (matchedTopics.length === 0) matched = false;
+        matched = matchTopics(articleTopics, filters.topics);
       }
-      //  must match at least one user selected topic
-      if (filters.userTopics) {
-        const userMatches = filters.userTopics.filter(userTopic => e.topics.includes(userTopic));
-        matched = userMatches.length > 0;
-      } 
 
-      if (filters.author && (e.author!=filters.author)) matched=false;
+      if (filters.userTopics) {
+        // either main topic (or child topics) or author must have matched
+        if ((filters.author || filters.topics) && matched) {
+          matched = matchTopics(articleTopics, filters.userTopics);
+        }
+      }
 
       if (filters.products) {
-        var productsMatched=false;
+        let productsMatched = false;
         filters.products.forEach((p) => {
-          if (e.products.includes(p)) productsMatched=true;
+          if (e.products.includes(p)) productsMatched = true;
         });
       }
       // match at least one selected product
-      if (filters.products && !productsMatched) matched=false;
+      if (filters.products && !productsMatched) matched = false;
 
       //check if path is already in a card
       if (document.querySelector(`.card a[href='/${getCardPath(e.path)}']`)) matched=false;


### PR DESCRIPTION
Fix #490 

The filter query is supposed to work like this:
topic AND (product1 OR product2 ...) AND (industry1 OR industry2 ...)

Error reproduction steps:
1. Go to https://blog.adobe.com/en/topics/creativity.html
2. Filter for industry _B2B_
3. See many _B2B_ articles that have nothing to do with _Creativity_ (unexpected)

Test fix:
1. Go to https://filter-query--theblog--adobe.hlx.page/en/topics/creativity.html
2. Filter for industry _B2B_ (wait for a few minutes for all index segements to load) 
3. See 5 articles that are all tagged _Creativity_ and _B2B_ (expected)
