### PR TITLE
feat(taxonomy): accept and handle links on topics in taxonomy

### DIFF
--- a/scripts/post.js
+++ b/scripts/post.js
@@ -523,11 +523,12 @@ function fetchAuthor() {
 /**
  * Adds the primary topic as category to the post header
  */
-function addCategory() {
+async function addCategory() {
   if (!window.blog.topics || window.blog.topics.length === 0) return;
   const topic = window.blog.topics[0];
   const categoryWrap = document.createElement('div');
-  const href = getLink(window.blog.TYPE.TOPIC, topic.replace(/\s/gm, '-').toLowerCase());
+  const taxonomy = await getTaxonomy();
+  const href = taxonomy.getLink(topic) || getLink(window.blog.TYPE.TOPIC, topic.replace(/\s/gm, '-').toLowerCase());
   categoryWrap.className = 'category';
   categoryWrap.innerHTML = `<a href="${href}" title="${topic}">${topic}</a>`;
   document.querySelector('main .post-header').prepend(categoryWrap);
@@ -536,12 +537,14 @@ function addCategory() {
 /**
  * Adds buttons for all topics to the bottom of the post
  */
-function addTopics() {
+async function addTopics() {
   if (!window.blog.topics || window.blog.topics.length === 0) return;
   const topicsWrap = createTag('div', { 'class' : 'topics' });
+  const taxonomy = await getTaxonomy();
   window.blog.topics.forEach((topic) => {
+    const href = taxonomy.getLink(topic) || getLink(window.blog.TYPE.TOPIC, topic.replace(/\s/gm, '-').toLowerCase());
     const btn = createTag('a', {
-      href: getLink(window.blog.TYPE.TOPIC, topic.replace(/\s/gm, '-').toLowerCase()),
+      href,
       title: topic,
     });
     btn.innerText = topic;
@@ -738,10 +741,10 @@ window.addEventListener('load', async function() {
   decorateLinkedImages();
   addInterLinks().then(() => handleLinks());
   addPredictedPublishURL();
-  addCategory();
+  await addCategory();
   fetchAuthor();
   await handleAsyncMetadata();
-  addTopics();
+  await addTopics();
   loadGetSocial();
   shapeBanners();
   fetchArticles();

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -39,6 +39,13 @@ export async function getTaxonomy() {
           }
 
           e.setAttribute('data-topic', topic.trim());
+          if (e.firstChild.nodeName === 'A') {
+            // topic could be a link
+            const link = e.firstChild.getAttribute('href');
+            if (link) {
+              e.setAttribute('data-topic-link', link);
+            }
+          }
         }
       });
 
@@ -97,6 +104,22 @@ export async function getTaxonomy() {
             console.error(`skipMeta error with topic "${topic}"`, error);
             return false;
           }
+        },
+
+        getLink: function (topic) {
+          try {
+            const n = this.node.querySelector(`[data-topic="${escapeTopic(topic)}"]`);
+            const link = n ? n.getAttribute('data-topic-link') : null;
+            if (link) {
+              // adapt host to current browser host
+              const u = new URL(link);
+              const current = new URL(window.location.href);
+              return `${current.origin}${u.pathname}`;
+            }
+          } catch (error) {
+            console.error(`getLink error with topic "${topic}"`, error);
+          }
+          return null;
         },
 
         getParents: function (topic) {


### PR DESCRIPTION
Allow the topics in the taxonomy document to be links: the link will be used instead of the magic computation we do based on the topic name.