### PR TITLE
feat(landingpage): allow to specify topics, products and new exclude

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -542,7 +542,6 @@ export async function fetchArticles({
   }
   window.blog.page = window.blog.page === undefined ? 0 : window.blog.page + 1;
   if (!(filters.pathsOnly && filters.paths.length==0)) {
-    console.log('filters', filters);
     const result=await fetchHits(filters, pageSize, window.blog.cursor?window.blog.cursor:0);
     const hits=result.hits;
     const setFocus=window.blog.page?true:false;

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -587,9 +587,9 @@ export function extractTopicsAndProducts() {
     topicContainer.remove();
   }
 
+  // raw topics (i.e as written in the source document)
   window.blog.topics = topics;
 
-  // store products as topics
   let products, productContainer;
   Array.from(last.children).forEach((i) => {
     const r = /^Products\: ?(.*)$/gmi.exec(i.innerText);
@@ -599,13 +599,10 @@ export function extractTopicsAndProducts() {
     }
   });
 
-  window.blog.topicsOnly = window.blog.topics;
-
+  // raw products (i.e as written in the source document)
   window.blog.products = products
-  ? products.filter((product) => product.length > 0)
-  : [];
-
-  window.blog.topics = window.blog.topics.concat(window.blog.products);
+    ? products.filter((product) => product.length > 0)
+    : [];
 
   if (productContainer) {
     productContainer.remove();

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -20,7 +20,12 @@ import {
   fetchArticles,
   fetchArticleIndex,
   itemTransformer,
+  extractTopicsAndProducts,
 } from '/scripts/common.js';
+
+import {
+  getTaxonomy
+} from '/scripts/taxonomy.js';
 
 /**
  * Sets up the homepage
@@ -85,7 +90,24 @@ async function setupHomepage() {
     addCard(n, newsdeck)
   });
 
+  extractTopicsAndProducts();
+
+  const filters = {};
+
+  if (window.blog.topicsOnly && window.blog.topicsOnly.length > 0) {
+    filters.topics = window.blog.topicsOnly.map(t => t.toLowerCase());
+  }
+
+  if (window.blog.products && window.blog.products.length > 0) {
+    filters.products = window.blog.products.map(p => p.toLowerCase());
+  }
+
+  if (window.blog.exclude && window.blog.exclude.length > 0) {
+    filters.exclude = window.blog.exclude.map(p => p.toLowerCase());
+  }
+
   await fetchArticles({
+    filters,
     pageSize: 13,
     callback: () => {
       if (window.blog.page === 0) {

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -94,8 +94,8 @@ async function setupHomepage() {
 
   const filters = {};
 
-  if (window.blog.topicsOnly && window.blog.topicsOnly.length > 0) {
-    filters.topics = window.blog.topicsOnly.map(t => t.toLowerCase());
+  if (window.blog.topics && window.blog.topics.length > 0) {
+    filters.topics = window.blog.topics.map(t => t.toLowerCase());
   }
 
   if (window.blog.products && window.blog.products.length > 0) {

--- a/scripts/post.js
+++ b/scripts/post.js
@@ -90,7 +90,7 @@ async function handleAsyncMetadata() {
 
   const allProducts = Array.from(new Set([
     ...window.blog.products,
-    ...taxonomy.getParents(taxonomy, window.blog.products, taxonomy.PRODUCTS),
+    ...taxonomy.getParents(window.blog.products, taxonomy.PRODUCTS),
   ]));
   
 

--- a/scripts/post.js
+++ b/scripts/post.js
@@ -90,7 +90,7 @@ async function handleAsyncMetadata() {
 
   const allProducts = Array.from(new Set([
     ...window.blog.products,
-    ...getParentTopics(taxonomy, window.blog.products, taxonomy.PRODUCTS),
+    ...taxonomy.getParents(taxonomy, window.blog.products, taxonomy.PRODUCTS),
   ]));
   
 
@@ -109,6 +109,26 @@ async function handleAsyncMetadata() {
         content: topic,
       }
     }));
+
+  // topics + parents
+  window.blog.allTopics = allTopics;
+
+  // products + parents
+  window.blog.allProducts = allProducts;
+
+  // UFT topics + parents
+  window.blog.allVisibleTopics = allTopics
+    .filter(topic => taxonomy.isUFT(topic));
+
+  // UFT products + parents
+  window.blog.allVisibleProducts = allProducts
+    .filter(topic => taxonomy.isUFT(topic, taxonomy.PRODUCTS));
+
+  // UFT topics + products + parents
+  window.blog.allVisibleTags = Array.from(new Set([
+    ...window.blog.allVisibleTopics,
+    ...window.blog.allVisibleProducts,
+  ]));
 }
 
 function toClassName(name) {


### PR DESCRIPTION
Fix #521 

PR allows to specify in "home" page (any page which is not under drafts, publish, author or topics I assume) in the last section: 
- `Topics: ` - (same as in articles) list of topics the articles on the page must have to be visible
- `Products: ` - (same as in articles) list of products the articles on the page must have to be visible
- `Exclude: ` - (new) list of topics and / or products which automatically exclude an article to appear on the page.

Exclude is mainly meant to be use on the homepage to exclude the region "Exclusive" articles.

The last section of a landing page could look like this:

```
Topics: Commerce, Trends & Research
Products: Creative Cloud 
Exclude: CMO By Adobe 
```

which means only articles with topics `Commerce` and `Trends & Research` and product `Creative Cloud` but not the ones that contains article `CMO By Adobe` will be shown on the page.

This would allow us to configure the homepage with:

```
Exclude: Exclusive
```

and the UK landing page:

```
Topics: UK
```

cc @rofe @davidnuescheler WDYT ?