### PR TITLE
feat(taxonomy): Taxonomy topic can appear twice

### DIFF
--- a/scripts/common.js
+++ b/scripts/common.js
@@ -369,7 +369,7 @@ async function translateTable(pages, index) {
 
     r.products = products;
     products.forEach((product) => {
-      r.products = r.products.concat(taxonomy.getParents(product));
+      r.products = r.products.concat(taxonomy.getParents(product, taxonomy.PRODUCTS));
     });
 
 
@@ -513,8 +513,8 @@ export async function fetchArticles({
   } else if (window.blog.pageType === window.blog.TYPE.TOPIC) {
     const taxonomy = await getTaxonomy(window.blog.language);
     const currentTopic = document.title.trim();
-    let topics = [currentTopic].concat(taxonomy.getChildren(currentTopic));
-    if (currentTopic.includes('Adobe ')) topics = topics.concat(taxonomy.getChildren(currentTopic.replace('Adobe ', '')));
+    const topic = taxonomy.lookup(currentTopic);
+    let topics = topic ? [topic.name].concat(topic.children) : [];
     filters.topics = topics.map(topic => topic.toLowerCase());
     if (window.blog.userFilters) {
       Object.keys(window.blog.userFilters).forEach((cat) => {

--- a/scripts/filters.js
+++ b/scripts/filters.js
@@ -287,11 +287,12 @@ async function drawFilterBar(callback) {
   filterBar.innerHTML = html;
 
   filterBar.querySelectorAll('.dropdown').forEach((dropdown) => {
-    const cat = taxonomy.getCategory(dropdown.id);
+    const categoryName = dropdown.id;
+    const cat = taxonomy.getCategory(categoryName);
     let optionsHTML = '';
     if (cat) {
-      cat.forEach((name) => {
-        const item = taxonomy.get(name);
+      cat.forEach((topic) => {
+        const item = taxonomy.get(topic, categoryName);
         if (item.level === 1) {
           const lname = item.name.replace(/\*/gm, '');
           optionsHTML += `<div class="option option">

--- a/scripts/taxonomy.js
+++ b/scripts/taxonomy.js
@@ -28,6 +28,12 @@ const INDUSTRIES = 'industries';
 const INTERNALS = 'internals';
 let _taxonomy;
 
+/**
+ * Returns the taxonomy object
+ * @param {string} lang Language of the taxonomy
+ * @param {*} url URL to use to load the taxonomy
+ * @returns {object} The taxonomy object
+ */
 export async function getTaxonomy(lang, url) {
   if (_taxonomy) {
     return _taxonomy;

--- a/test/features/taxonomy/en.json
+++ b/test/features/taxonomy/en.json
@@ -89,6 +89,51 @@
       "Level 3": "",
       "Link": "",
       "Type": "Internals"
+    },
+    {
+      "ExcludeFromMetadata": "X",
+      "Hidden": "",
+      "Level 1": "Top400",
+      "Level 2": "",
+      "Level 3": "",
+      "Link": "",
+      "Type": "Products"
+    },
+    {
+      "ExcludeFromMetadata": "",
+      "Hidden": "",
+      "Level 1": "",
+      "Level 2": "Top240",
+      "Level 3": "",
+      "Link": "https://www.anotherlink.com",
+      "Type": "Products"
+    },
+    {
+      "ExcludeFromMetadata": "X",
+      "Hidden": "X",
+      "Level 1": "",
+      "Level 2": "",
+      "Level 3": "Top241",
+      "Link": "",
+      "Type": "Products"
+    },
+    {
+      "ExcludeFromMetadata": "",
+      "Hidden": "",
+      "Level 1": "",
+      "Level 2": "",
+      "Level 3": "Top242",
+      "Link": "",
+      "Type": "Products"
+    },
+    {
+      "ExcludeFromMetadata": "",
+      "Hidden": "",
+      "Level 1": "",
+      "Level 2": "Top410",
+      "Level 3": "",
+      "Link": "",
+      "Type": "Products"
     }
   ]
 }

--- a/test/unit/taxonomy.test.js
+++ b/test/unit/taxonomy.test.js
@@ -40,14 +40,64 @@ describe('Taxonomy', () => {
     expect(top211.category).to.eql('Categories');
   });
 
+  it('getTaxonomy#get can find by category', () => {
+    const product241 = taxonomy.get('Top241', taxonomy.PRODUCTS);
+    expect(product241).to.not.be.null;
+    expect(product241.category).to.not.be.null;
+    expect(product241.category.toLowerCase()).to.equal(taxonomy.PRODUCTS);
+
+    const category241 = taxonomy.get('Top241', taxonomy.CATEGORIES);
+    expect(category241).to.not.be.null;
+    expect(category241.category).to.not.be.null;
+    expect(category241.category.toLowerCase()).to.equal(taxonomy.CATEGORIES);
+  });
+
+  it('getTaxonomy#lookup products have priority', () => {
+    const top241 = taxonomy.lookup('Top241',);
+    expect(top241).to.not.be.null;
+    expect(top241.category).to.not.be.null;
+    expect(top241.category.toLowerCase()).to.equal(taxonomy.PRODUCTS);
+  });
+
+  it('getTaxonomy#lookup finds a tag', () => {
+    const top100 = taxonomy.lookup('Top100',);
+    expect(top100).to.not.be.null;
+    expect(top100.category).to.not.be.null;
+    expect(top100.category.toLowerCase()).to.equal(taxonomy.CATEGORIES);
+  });
+
+  it('getTaxonomy#lookup finds Adobe products', () => {
+    const top241 = taxonomy.lookup('Adobe Top241',);
+    expect(top241).to.not.be.null;
+    expect(top241.category).to.not.be.null;
+    expect(top241.category.toLowerCase()).to.equal(taxonomy.PRODUCTS);
+  });
+
+  it('getTaxonomy#lookup does not find a tag with Adobe', () => {
+    const top100 = taxonomy.lookup('Adobe Top100',);
+    expect(top100).to.be.null;
+  });
+
   it('getTaxonomy#isUFT', () => {
     expect(taxonomy.isUFT('Top100')).to.be.true;
     expect(taxonomy.isUFT('Top200')).to.be.false;
   });
 
+  it('getTaxonomy#isUFT makes difference between categories', () => {
+    expect(taxonomy.isUFT('Top241')).to.be.true;
+    expect(taxonomy.isUFT('Top241', taxonomy.CATEGORIES)).to.be.true;
+    expect(taxonomy.isUFT('Top241', taxonomy.PRODUCTS)).to.be.false;
+  });
+
   it('getTaxonomy#skipMeta', () => {
     expect(taxonomy.skipMeta('Top300')).to.be.true;
     expect(taxonomy.skipMeta('Top211')).to.be.false;
+  });
+
+  it('getTaxonomy#skipMeta makes difference between categories', () => {
+    expect(taxonomy.skipMeta('Top241')).to.be.false;
+    expect(taxonomy.skipMeta('Top241', taxonomy.CATEGORIES)).to.be.false;
+    expect(taxonomy.skipMeta('Top241', taxonomy.PRODUCTS)).to.be.true;
   });
 
   it('getTaxonomy#getParents', () => {
@@ -71,6 +121,13 @@ describe('Taxonomy', () => {
     expect(taxonomy.getParents('Top110')).to.eql([]);
   });
 
+  it('getTaxonomy#getParents makes difference between categories', () => {
+
+    expect(taxonomy.getParents('Top241')).to.eql(['Top240', 'Top200']);
+    expect(taxonomy.getParents('Top241', taxonomy.CATEGORIES)).to.eql(['Top240', 'Top200']);
+    expect(taxonomy.getParents('Top241', taxonomy.PRODUCTS)).to.eql(['Top240', 'Top400']);
+  });
+
   it('getTaxonomy#getParents accept arrays', () => {
     expect(taxonomy.getParents(['Top211', 'Top212', 'Top241'])).to.eql(['Top210', 'Top200', 'Top240']);
     expect(taxonomy.getParents(['Top210', 'Top211'])).to.eql(['Top200', 'Top210']);
@@ -89,6 +146,15 @@ describe('Taxonomy', () => {
     expect(taxonomy.getChildren('Top300')).to.eql([]);
   });
 
+  it('getTaxonomy#getChildren makes difference between categories', () => {
+    expect(taxonomy.getChildren('Top200')).to.eql(['Top210', 'Top220', 'Top230', 'Top240']);
+    expect(taxonomy.getChildren('Top200', taxonomy.CATEGORIES)).to.eql(['Top210', 'Top220', 'Top230', 'Top240']);
+    expect(taxonomy.getChildren('Top200', taxonomy.PRODUCTS)).to.eql([]);
+    expect(taxonomy.getChildren('Top240')).to.eql(['Top241']);
+    expect(taxonomy.getChildren('Top240', taxonomy.CATEGORIES)).to.eql(['Top241']);
+    expect(taxonomy.getChildren('Top240', taxonomy.PRODUCTS)).to.eql(['Top241', 'Top242']);
+  });
+
   it('getTaxonomy#getCategory', () => {
     const internals = taxonomy.getCategory(taxonomy.INTERNALS);
     expect(internals.length).to.equal(1);
@@ -100,5 +166,15 @@ describe('Taxonomy', () => {
     expect(categories[1]).to.equal('Top200');
     expect(categories[2]).to.equal('Top210');
     expect(categories[3]).to.equal('Top211');
+  });
+
+  it('getTaxonomy#getCategory duplicates allowed in different categories', () => {
+    const internals = taxonomy.getCategory(taxonomy.PRODUCTS);
+    expect(internals.length).to.equal(5);
+    expect(internals[2]).to.equal('Top241');
+
+    const categories = taxonomy.getCategory(taxonomy.CATEGORIES);
+    expect(categories.length).to.equal(9);
+    expect(categories[8]).to.equal('Top241');
   });
 });

--- a/tools/sidekick/plugins.js
+++ b/tools/sidekick/plugins.js
@@ -139,7 +139,7 @@
       path: window.location.pathname.substring(1),
       teaser: d[6],
       title: d[7],
-      topics: [...window.blog.topics],
+      topics: [...window.blog.allVisibleTopics],
     };
   }
 
@@ -208,7 +208,7 @@
       `/hlx_${document.head.querySelector('meta[property="og:image"]')
         .getAttribute('content').split('/hlx_')[1]}`,
       predictUrl(null, sk.location.pathname),
-      '[]',
+      `["${window.blog.products.join('\", \"')}"]`,
       '0',
       document.querySelector('main>div:nth-of-type(4)').textContent.trim().substring(0, 75),
       document.title,

--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -376,20 +376,32 @@
       var products = '';
       var topics = '';
 
-      const tags = [];
+      let tags = [];
       selected.forEach((e) => {
         tags.push(fetchTag(e.name, e.category));
       });
-      // sort array to keep CATEGORIES logical order
-      tags.sort((t1, t2) => {
-        const i1 = CATEGORIES.indexOf(t1.category);
-        const i2 = CATEGORIES.indexOf(t2.category);
-        if (i1 <= i2) return -1;
-        return 1;
-      });
+
+      if (tags.length > 1) {
+        // sort array (except first element) to keep CATEGORIES logical order
+        const toSort = tags.splice(1);
+        toSort.sort((t1, t2) => {
+          const i1 = CATEGORIES.indexOf(t1.category);
+          const i2 = CATEGORIES.indexOf(t2.category);
+          if (i1 < i2) return -1;
+          if (i1 > i2) return 1;
+          
+          let i = t1.path.localeCompare(t2.path);
+          if (i === 0) {
+            return t1.tag.localeCompare(t2.tag);
+          }
+          return i;
+        });
+
+        tags = [tags[0]].concat(toSort);
+      }
 
       tags.forEach((tagInfo) => {
-        html += `<span data-target="${tagInfo.name}" data-category="${tagInfo.category}" onclick="remove(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${tagInfo.label}</span></span> `;
+        html += `<span data-target="${tagInfo.tag}" data-category="${tagInfo.category}" onclick="remove(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${tagInfo.label}</span></span> `;
         if (1 === CATEGORIES.indexOf(tagInfo.category)) products += tagInfo.tag + ', ';
         else topics += tagInfo.tag + ', ';
       });

--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -300,8 +300,8 @@
       CATEGORIES.push(_taxonomy.getCategoryTitle(_taxonomy.INTERNALS));
     }
 
-    function fetchTag(name) {
-      const item = _taxonomy.get(name);
+    function fetchTag(name, cat) {
+      const item = _taxonomy.get(name, cat);
       if (item) {
         const tag = name.replace(/[\*|\#]/gm, '').trim();
 
@@ -333,21 +333,29 @@
     })(document);
 
     function remove(e) {
-      var target = e.getAttribute('data-target');
-      selected.splice(selected.indexOf(target), 1);
+      const target = e.getAttribute('data-target');
+      const cat = e.getAttribute('data-category');
+      selected.splice(selected.findIndex(s => s.name === target && s.category === cat), 1);
       displaySelected();
     }
 
     function add(e) {
-      var target = e.getAttribute('data-target');
-      selected.push(target);
+      const target = e.getAttribute('data-target');
+      const cat = e.getAttribute('data-category');
+      selected.push({
+        name: target,
+        category: cat
+      });
       displaySelected();
     }
 
-    function addByName(name) {
-      const item = _taxonomy.get(name);
+    function addByName(name, cat) {
+      const item = _taxonomy.get(name, cat);
       if (item) {
-        selected.push(item.name);
+        selected.push({
+          name: item.name, 
+          category: cat 
+        });
         displaySelected();
       }
     }
@@ -370,7 +378,7 @@
 
       const tags = [];
       selected.forEach((e) => {
-        tags.push(fetchTag(e));
+        tags.push(fetchTag(e.name, e.category));
       });
       // sort array to keep CATEGORIES logical order
       tags.sort((t1, t2) => {
@@ -381,7 +389,7 @@
       });
 
       tags.forEach((tagInfo) => {
-        html += `<span data-target="${tagInfo.name}" onclick="remove(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${tagInfo.label}</span></span> `;
+        html += `<span data-target="${tagInfo.name}" data-category="${tagInfo.category}" onclick="remove(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${tagInfo.label}</span></span> `;
         if (1 === CATEGORIES.indexOf(tagInfo.category)) products += tagInfo.tag + ', ';
         else topics += tagInfo.tag + ', ';
       });
@@ -401,7 +409,9 @@
       copybuffer.value = `---\r\n\r\nTopics: ${topics}\r\nProducts: ${products}\r\n\r\n`
 
       document.querySelectorAll('#results>.category>span').forEach((e) => {
-        if (selected.indexOf(e.getAttribute('data-target')) < 0) {
+        const target = e.getAttribute('data-target');
+        const cat = e.getAttribute('data-category');
+        if (selected.findIndex(s => s.name === target && s.category === cat) < 0) {
           e.classList.remove('selected');
           e.setAttribute('onclick', 'add(this)');
         } else {
@@ -432,7 +442,7 @@
         html += `<h2>${cat}</h2>`;
         const items = _taxonomy.getCategory(cat);
         items.forEach((name) => {
-          var tagInfo = fetchTag(name);
+          var tagInfo = fetchTag(name, cat);
           if (tagInfo) {
             var label = tagInfo.label;
             var offset = label.toLowerCase().indexOf(searchTerm);
@@ -442,7 +452,7 @@
               term = label.substr(offset, searchTerm.length);
               after = label.substr(offset + searchTerm.length);
 
-              html += `<span data-target="${name}" onclick="add(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${before}<span class="highlight">${term}</span>${after}</span></span> `;
+              html += `<span data-target="${name}" data-category="${cat}" onclick="add(this)" class="path">${tagInfo.path}<span class="tag cat-${CATEGORIES.indexOf(tagInfo.category)}${tagInfo.nuft ? ' nuft' : ''}">${before}<span class="highlight">${term}</span>${after}</span></span> `;
             }
           }
         })
@@ -469,7 +479,7 @@
         }
 
         topics.forEach((t) => addByName(t));
-        products.forEach((p) => addByName(p));
+        products.forEach((p) => addByName(p, PRODUCTS));
       }
     }
 
@@ -512,14 +522,14 @@
       asyncForEach(CATEGORIES, async (cat, index) => {
         const items = _taxonomy.getCategory(cat);
         asyncForEach(items,async (name) => {
-          const tagInfo = fetchTag(name);
+          const tagInfo = fetchTag(name, cat);
           if (tagInfo) {
             const { tag, nuft } = tagInfo;
             const link = computeLink(tagInfo);
 
             if (link) {
               console.log(`checking link ${tag}: ${link}`, tagInfo);
-              const ui = document.querySelector(`#results [data-target="${name}"]`);
+              const ui = document.querySelector(`#results [data-target="${name}"][data-category="${cat}"]`);
               const icon = document.createElement('span');
               icon.classList = 'lcIcon';
               icon.innerHTML = LOADING_ICON;

--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -303,7 +303,7 @@
     function fetchTag(name, cat) {
       const item = _taxonomy.get(name, cat);
       if (item) {
-        const tag = name.replace(/[\*|\#]/gm, '').trim();
+        const tag = name.trim();
 
         const parents = item.parents.slice().reverse();
         const path = parents.join(' / ') + ' ';


### PR DESCRIPTION
A topic and a product can have the same name (e.g. Creative Cloud). This was "almost" supported before the change to the  xlsx spreadsheet. Authors want to have the feature back because the topic and the product serves different purposes (analytics tagging vs non visible topic vs product page).

While fixing the issue, I discover some existing bugs in how we were treating that case before: 
- https://blog.adobe.com/en/topics/creative-cloud.html does not show the correct list of entries (missing Creative Cloud product children)
- http://taxonomy-topic-can-appear-twice--theblog--adobe.hlx.page/en/topics/creative-cloud.html does contain the correct list now.
