### PR TITLE
feat(post): meta description authoring

### DIFF
--- a/style/post.css
+++ b/style/post.css
@@ -30,8 +30,9 @@
   padding: 0;
 }
 
-.post-page .post-title h3:empty {
-  display: none;
+.post-page .post-title h3:empty,
+.post-page .post-title p {
+    display: none;
 }
 
 .post-page .hero-image {

--- a/style/topic.css
+++ b/style/topic.css
@@ -57,6 +57,11 @@
   font-size: 1.125rem;
 }
 
+.topic-title .topic-title-container > p:not(:first-of-type) {
+  display: none;
+}
+
+
 .topic-title > img {
   display: none;
 }


### PR DESCRIPTION
Fix #544 

This small change lets authors add a regular text paragraph in the title section directly underneath the heading, which will not be displayed on the page but added to the page's metadata.

Special case topic page: here the first text paragraph after the heading is already reserved for the tagline, so any meta description must be added as the second paragraph underneath. Changing that (e.g. by moving the tagline to an `h2` or `h3`) would be a breaking change which I'm not sure is worth the effort.