### PR TITLE
chore: enable crawling for en, disable rest

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,11 +1,21 @@
 user-agent: *
 disallow: /archive
 disallow: /components
+disallow: /br/
+disallow: /de/
 disallow: /en/
 allow: /en/20*/
 allow: /en/publish/20*/
 allow: /en/authors/
 allow: /en/topics/
+disallow: /es/
+disallow: /fr/
+disallow: /it/
 disallow: /jp/
+disallow: /ko/
+allow: /ko/20*/
+allow: /ko/publish/20*/
+allow: /ko/authors/
+allow: /ko/topics/
 
 sitemap: https://blog.adobe.com/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -13,9 +13,5 @@ disallow: /fr/
 disallow: /it/
 disallow: /jp/
 disallow: /ko/
-allow: /ko/20*/
-allow: /ko/publish/20*/
-allow: /ko/authors/
-allow: /ko/topics/
 
 sitemap: https://blog.adobe.com/sitemap.xml


### PR DESCRIPTION
Looks like we forgot to explicitly exclude some language folders. Also we want to allow crawlers into /ko/* now.