### PR TITLE
feat(tagger): fit all categories on smaller screens

### DIFF
--- a/tools/tagger/index.html
+++ b/tools/tagger/index.html
@@ -70,7 +70,7 @@
     main > div > span,
     main > div > div > span {
       white-space: nowrap;
-      margin: 10px;
+      margin: 6px 4px;
     }
 
     main {


### PR DESCRIPTION
Reduce spacing to allow the `Internals` to fit on smaller screens.