### PR TITLE
feat(sidekick): prepare for preload plugin

### DIFF
--- a/tools/sidekick/plugins.js
+++ b/tools/sidekick/plugins.js
@@ -28,7 +28,7 @@
   sk.add({
     id: 'preview',
     override: true,
-    condition: (sidekick) => sidekick.isEditor() || (sidekick.isHelix() && sidekick.config.host),
+    condition: (s) => s.isEditor() || s.location.host === s.config.host,
     button: {
       action: () => {
         const { config, location } = sk;


### PR DESCRIPTION
Adjust to https://github.com/adobe/helix-pages/pull/733 (preview and reload button should not both appear on the inner CDN)