### PR TITLE
feat(promotion): preview and publish promotions

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -150,6 +150,7 @@ window.blog = function() {
     AUTHOR: 'author',
     TOPIC: 'topic',
     PRODUCT: 'product',
+    PROMOTION: 'promotion',
     BLANK: 'blank',
   };
   const LANG = {

--- a/scripts/promotion.js
+++ b/scripts/promotion.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {
+  createTag,
+  wrap,
+  wrapNodes,
+  getSection,
+} from '/scripts/common.js';
+
+async function decoratePromotionPage() {
+  document.body.classList.add('post-page');
+  // wrap section with embed container
+  wrap('embed embed-internal embed-internal-adobesensei embed-internal-products embed-internal-promotions',
+    'main>div');
+  // add post sections
+  ['post-header', 'post-author', 'hero-image', 'post-body'].forEach((cl) => {
+    document.querySelector('main').appendChild(createTag('div', { class: cl }));
+  });
+  // move promotion to post body
+  document.querySelector('.post-body').appendChild(document.querySelector('.embed-internal-promotions'));
+  // decorate promotion
+  const $e = document.querySelector('.post-body .embed-internal>div:not(.banner)');
+  $e.parentNode.classList.add('embed-internal-promotions');
+  const children = Array.from($e.childNodes);
+  children.shift();
+  const parent = createTag('div', { 'class' : 'embed-promotions-text' });
+  wrapNodes(parent, children);
+}
+
+function addDependencies() {
+  window.hlx = window.hlx || {};
+  window.hlx.dependencies = [
+    window.location.pathname.replace('.html', '.embed.html'),
+    window.location.pathname.toLowerCase().replace('.html', '.embed.html'),
+  ];
+}
+
+window.addEventListener('load', () => {
+  loadCSS('/style/post.css');
+  decoratePromotionPage();
+  addDependencies();
+});
+

--- a/style/promotion.css
+++ b/style/promotion.css
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+.promotion-page main {
+  visibility: visible;
+}
+
+.promotion-page.post-page .post-author,
+.promotion-page.post-page .hero-image {
+  display: none;
+}


### PR DESCRIPTION
Fix #411 and enable publication of promotions

Example: https://promo-preview--theblog--adobe.hlx.page/en/promotions/products/creative-cloud/premiere-pro-user-guide.html