### PR TITLE
fix(font): temp fix - load Adobe Clean version that supports DE, BR, ES and FR

### DIFF
--- a/head.html
+++ b/head.html
@@ -32,9 +32,8 @@
 </style>
 <!-- async css loading -->
 <link rel="stylesheet" href="/style.css"/>
+<link rel="stylesheet" href="/hlx_fonts/inq1xob.css"/>
 <link rel="stylesheet" href="/hlx_fonts/aaz7dvd.css"/>
-<link rel="stylesheet" href="/hlx_fonts/dvg6awq.css"/>
-<link rel="stylesheet" href="/hlx_fonts/qjs5sfm.css"/>
 <link rel="publisher" href="https://www.facebook.com/Adobe"/>
 
 <script src="/scripts.js"></script>

--- a/head.html
+++ b/head.html
@@ -32,7 +32,9 @@
 </style>
 <!-- async css loading -->
 <link rel="stylesheet" href="/style.css"/>
-<link rel="stylesheet" href="/hlx_fonts/inq1xob.css"/>
+<link rel="stylesheet" href="/hlx_fonts/aaz7dvd.css"/>
+<link rel="stylesheet" href="/hlx_fonts/dvg6awq.css"/>
+<link rel="stylesheet" href="/hlx_fonts/qjs5sfm.css"/>
 <link rel="publisher" href="https://www.facebook.com/Adobe"/>
 
 <script src="/scripts.js"></script>


### PR DESCRIPTION
Authors keep reporting font issues ("umlauts have been bolded in our blog posts", "The special characters in BR Portuguese and Spanish is showing a different font, there is something we can fix?"). The `Adobe Clean` version that we load from the `inq1xob` kit does not seem to contain those special characters. But we also need `Adobe Clean Han Japanese` for JP and `Adobe Clean Han K` for KO.

While we find the way to create the correct kit that contains what we need or we migrate to specific font loading (https://github.com/adobe/theblog/issues/664), this is a temp fix that should solve the font issue. It is a bit dirty because it loads 2 versions of Adobe Clean but it seems to work. Tested on:
- https://fontkit--theblog--adobe.hlx.page/es/publish/2021/04/23/como-crear-una-exitosa-parrilla-de-social-media.html#gs.zoycun
- https://fontkit--theblog--adobe.hlx.page/br/publish/2021/04/28/5-tendencias-imperdiveis-de-marketing-digital.html#gs.zoycnj
- https://fontkit--theblog--adobe.hlx.page/de/publish/2021/03/17/multi-frame-rendering-beta-version-after-effects.html#gs.zoyd3x
- https://fontkit--theblog--adobe.hlx.page/de/publish/2021/03/17/multi-frame-rendering-beta-version-after-effects.html#gs.zoyd3x

where things look correct.