### PR TITLE
remove publish button from sheets

### DIFF
--- a/tools/sidekick/plugins.js
+++ b/tools/sidekick/plugins.js
@@ -28,7 +28,7 @@
   sk.add({
     id: 'preview',
     override: true,
-    condition: (s) => s.isEditor() || s.location.host === s.config.host,
+    condition: (s) => s.isEditor() || s.isHelix(),
     button: {
       action: (evt) => {
         const { config, location } = sk;
@@ -263,7 +263,7 @@
       action: async () => {
         const { config } = sk;
         sk.showModal('Publishing data...', true);
-        const url = new URL('https://adobeioruntime.net/api/v1/web/helix/helix-services/content-proxy@v2');
+        const url = new URL('https://helix-pages.anywhere.run/helix-services/content-proxy@v2');
         url.search = new URLSearchParams([
           ['report', 'true'],
           ['owner', config.owner],

--- a/tools/sidekick/plugins.js
+++ b/tools/sidekick/plugins.js
@@ -245,49 +245,4 @@
       return sidekick.isHelix() && !sidekick.location.pathname.includes('/drafts/');
     },
   });
-
-  // PUBLISH TAXONOMY & REDIRECTS--------------------------------------------------
-
-  sk.add({
-    id: 'publish-data',
-    condition: (sk) => {
-      const { config, location } = sk;
-      return config.innerHost
-        && config.host
-        && sk.isEditor()
-        && (location.search.includes('file=_taxonomy.xlsx') || location.search.includes('file=redirects.xlsx'));
-    },
-    override: true,
-    button: {
-      text: 'Publish',
-      action: async () => {
-        const { config } = sk;
-        sk.showModal('Publishing data...', true);
-        const url = new URL('https://helix-pages.anywhere.run/helix-services/content-proxy@v2');
-        url.search = new URLSearchParams([
-          ['report', 'true'],
-          ['owner', config.owner],
-          ['repo', config.repo],
-          ['ref', config.ref || 'main'],
-          ['path', '/'],
-          ['lookup', location.href],
-        ]).toString();
-        const resp = await fetch(url.toString());
-        const json = await resp.json();
-        if (!resp.ok || !json.unfriendlyWebUrl) {
-          sk.notify('Failed to publish taxonomy. Please try again later.', 0);
-          console.log('error', JSON.stringify(await resp.json()));
-        }
-        const path = new URL(json.unfriendlyWebUrl).pathname;
-        const purge = await sk.publish(path);
-        if (purge.ok) {
-          await fetch(json.unfriendlyWebUrl, {cache: 'reload', mode: 'no-cors'});
-          sk.notify('Data published');
-        } else {
-          sk.notify('Failed to publish data. Please try again later.', 0);
-          console.log('error', JSON.stringify(purge));
-        }
-      },
-    },
-  });
 })();


### PR DESCRIPTION
Publishing spreadhseets directly from Excel currently no longer works with the way we purge via `POST` (CORS). The workaround is to first click preview, then publish from there.