### PR TITLE
chore: add naver webmaster tool verification file

### DIFF
--- a/naver2a5f3540429b73b4ab57db9180917416.html
+++ b/naver2a5f3540429b73b4ab57db9180917416.html
@@ -1,0 +1,1 @@
+naver-site-verification: naver2a5f3540429b73b4ab57db9180917416.html


### PR DESCRIPTION
> Our APAC SEO team would like to verify the blog.adobe.com to the Naver webmaster (a similar tool as Google search console, but Korea version), can you please help (or direct me to the right team that can help) adding the verification code file?