### PR TITLE
Core Web Vitals logging

### DIFF
--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -139,3 +139,36 @@ loadScript('https://www.adobe.com/marketingtech/main.min.js', () => {
 loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js').id = 'feds-script';
 loadScript('https://static.adobelogin.com/imslib/imslib.min.js');
 
+console.log('this');
+
+/* Core Web Vitals */
+const weight = 1;
+window.hlx.cwv = {};
+
+function storeCWV(measurement) {
+  window.hlx.cwv[measurement.name] = measurement.value; 
+}
+
+if (Math.random() * weight < 1) {
+  var script = document.createElement('script');
+  script.src = 'https://unpkg.com/web-vitals';
+  script.onload = function() {
+    // When loading `web-vitals` using a classic script, all the public
+    // methods can be found on the `webVitals` global namespace.
+    webVitals.getCLS(storeCWV);
+    webVitals.getFID(storeCWV);
+    webVitals.getLCP(storeCWV);
+  }
+  document.head.appendChild(script);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      const body = JSON.stringify(window.hlx.cwv);
+      const url = `/.rum/${weight}`;
+      console.log (url, body);
+
+      // Use `navigator.sendBeacon()` if available, falling back to `fetch()`.
+      (navigator.sendBeacon && navigator.sendBeacon(url, body)) ||
+          fetch(url, {body, method: 'POST', keepalive: true});
+      }
+  });
+}

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -141,6 +141,7 @@ loadScript('https://static.adobelogin.com/imslib/imslib.min.js');
 
 /* Core Web Vitals */
 const weight = 1;
+window.hlx = window.hlx || {};
 window.hlx.cwv = {};
 
 function storeCWV(measurement) {

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -139,8 +139,6 @@ loadScript('https://www.adobe.com/marketingtech/main.min.js', () => {
 loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js').id = 'feds-script';
 loadScript('https://static.adobelogin.com/imslib/imslib.min.js');
 
-console.log('this');
-
 /* Core Web Vitals */
 const weight = 1;
 window.hlx.cwv = {};

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -140,7 +140,7 @@ loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.
 loadScript('https://static.adobelogin.com/imslib/imslib.min.js');
 
 /* Core Web Vitals */
-const weight = 1;
+const weight = 100;
 window.hlx = window.hlx || {};
 window.hlx.rum = { cwv:{}, weight};
 

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -142,10 +142,10 @@ loadScript('https://static.adobelogin.com/imslib/imslib.min.js');
 /* Core Web Vitals */
 const weight = 1;
 window.hlx = window.hlx || {};
-window.hlx.cwv = {};
+window.hlx.rum = { cwv:{}, weight};
 
 function storeCWV(measurement) {
-  window.hlx.cwv[measurement.name] = measurement.value; 
+  window.hlx.rum.cwv[measurement.name] = measurement.value; 
 }
 
 if (Math.random() * weight < 1) {
@@ -161,7 +161,7 @@ if (Math.random() * weight < 1) {
   document.head.appendChild(script);
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') {
-      const body = JSON.stringify(window.hlx.cwv);
+      const body = JSON.stringify(window.hlx.rum);
       const url = `/.rum/${weight}`;
       console.log (url, body);
 


### PR DESCRIPTION
testing some core web vitals logging with a sample rate controlled by `weight`
currently set to `1` for testing but i think we should set this probably to `100` when we merge this...