### PR TITLE
feat(cwv): improve CWV persistence

### DIFF
--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -164,7 +164,10 @@ function storeCWV(measurement) {
   store(rum);
 }
 
-if (Math.random() * weight < 1) {
+const usp = new URLSearchParams(window.location.search);
+const cwv = usp.get('cwv');
+
+if (cwv === 'on' || Math.random() * weight < 1) {
   // store a page view
   store({ weight, id });
 

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -146,19 +146,28 @@ window.hlx = window.hlx || {};
 const hashCode = (s) => s.split('').reduce((a,b) => (((a << 5) - a) + b.charCodeAt(0))|0, 0);
 const id = `${hashCode(window.location.href)}-${new Date().getTime()}-${Math.random().toString(16).substr(2, 14)}`;
 
-function storeCWV(measurement) {
-  const rum = { cwv:{}, weight, id};
-  rum.cwv[measurement.name] = measurement.value;
-
-  const body = JSON.stringify(rum);
+function store(data) {
+  const body = JSON.stringify(data);
   const url = `/.rum/${weight}`;
-  
+
+  // console.log('storing', body);
+
   // Use `navigator.sendBeacon()` if available, falling back to `fetch()`.
   (navigator.sendBeacon && navigator.sendBeacon(url, body)) ||
       fetch(url, {body, method: 'POST', keepalive: true});
 }
 
+function storeCWV(measurement) {
+  const rum = { cwv:{}, weight, id };
+  rum.cwv[measurement.name] = measurement.value;
+
+  store(rum);
+}
+
 if (Math.random() * weight < 1) {
+  // store a page view
+  store({ weight, id });
+
   var script = document.createElement('script');
   script.src = 'https://unpkg.com/web-vitals';
   script.onload = function() {


### PR DESCRIPTION
Sending the data on visibility change is not optimal because the LCP and CLS events might be fired only on page unload, i.e. after the last visibility change - data are then missing, we can observe a lot of empty entries in the logs.

Only viable solution is to send the data when events are fired, which means multiple requests and then multiple log entries. To be able to reconcile the data, I added an id (url hash + timestamp + generated number, probability this is not unique is almost null).

I also added a "page view" entry so that we can observe if the CWV metrics are always persisted or not (might be cases where they are missing). We also get an estimate of the page views (unique ids * 100).

I also added support for `?cwv=on` request parameter so that we can skip the weight computation (useful for testing).