### PR TITLE
chore: transform blob video url

### DIFF
--- a/scripts/v2/post.js
+++ b/scripts/v2/post.js
@@ -799,7 +799,7 @@ function decorateAnimations() {
 
       const $video=createTag('video', attribs);
       if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
-        href='/hlx_'+href.split('/')[4].replace('#image','');
+        href='/hlx_'+href.split('/')[4].replace('#image','').replace('#video', '');
       }
       $video.innerHTML=`<source src="${href}" type="video/mp4">`;
       $a.parentNode.replaceChild($video, $a);

--- a/scripts/v2/post.js
+++ b/scripts/v2/post.js
@@ -799,7 +799,8 @@ function decorateAnimations() {
 
       const $video=createTag('video', attribs);
       if (href.startsWith('https://hlx.blob.core.windows.net/external/')) {
-        href='/hlx_'+href.split('/')[4].replace('#image','').replace('#video', '');
+        const { pathname } = new URL(href);
+        href = pathname.replace('external/', 'media_') + '.mp4';
       }
       $video.innerHTML=`<source src="${href}" type="video/mp4">`;
       $a.parentNode.replaceChild($video, $a);


### PR DESCRIPTION
## Description

video links for mp4 animations are not being transformed properly

## Links

before: https://master--theblog--adobe.hlx.page/en/drafts/jennie/adobe-stock-motion-trend-eye-catching-transformative-transitions.html

after: https://block-animation--theblog--adobe.hlx.page/en/drafts/jennie/adobe-stock-motion-trend-eye-catching-transformative-transitions.html

existing animation blocks do not appear to be impacted by this change: https://block-animation--theblog--adobe.hlx.page/en/publish/2021/08/17/photoshop-releases-major-update-sky-replacement-healing-brush-magic-wand-on-ipad-much-more.html