### PR TITLE
microfunnel: update for unsupported browsers

### DIFF
--- a/head.html
+++ b/head.html
@@ -21,5 +21,5 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png"/>
 <link rel="apple-touch-icon-precomposed" href="/icons/apple-touch-icon-precomposed.png"/>
 <script>
-    if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
+    if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+encodeURIComponent(data); }
 </script>

--- a/head.html
+++ b/head.html
@@ -20,3 +20,6 @@
 <link rel="apple-touch-icon" sizes="167x167" href="/icons/apple-touch-icon-167x167.png"/>
 <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png"/>
 <link rel="apple-touch-icon-precomposed" href="/icons/apple-touch-icon-precomposed.png"/>
+<script>
+    if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
+</script>

--- a/head.html
+++ b/head.html
@@ -21,5 +21,14 @@
 <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon-180x180.png"/>
 <link rel="apple-touch-icon-precomposed" href="/icons/apple-touch-icon-precomposed.png"/>
 <script>
-    if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+encodeURIComponent(data); }
+    if (!navigator.sendBeacon) { 
+    var hashCode = function hashCode(s) {
+      return s.split('').reduce(function (a, b) {
+        return (a << 5) - a + b.charCodeAt(0) | 0;
+      }, 0);
+    };
+
+    var id = "".concat(hashCode(window.location.href), "-").concat(new Date().getTime(), "-").concat(Math.random().toString(16).substr(2, 14));
+
+    var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1, id: id }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+encodeURIComponent(data); }
 </script>

--- a/scripts/v2/scripts.js
+++ b/scripts/v2/scripts.js
@@ -18,7 +18,7 @@
  */
 
 // eslint-disable-next-line
-if (!navigator.sendBeacon) { window.data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); new Image().src = 'https://rum.hlx3.page/.rum/1?data='+window.data; }
+if (!navigator.sendBeacon) { data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
 
 // eslint-disable-next-line import/prefer-default-export
 function sampleRUM(checkpoint, data = {}) {

--- a/scripts/v2/scripts.js
+++ b/scripts/v2/scripts.js
@@ -18,7 +18,7 @@
  */
 
 // eslint-disable-next-line
-if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
+if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; document.appendChild(img); }
 
 // eslint-disable-next-line import/prefer-default-export
 function sampleRUM(checkpoint, data = {}) {

--- a/scripts/v2/scripts.js
+++ b/scripts/v2/scripts.js
@@ -18,7 +18,7 @@
  */
 
 // eslint-disable-next-line
-if (!navigator.sendBeacon) { data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
+if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; }
 
 // eslint-disable-next-line import/prefer-default-export
 function sampleRUM(checkpoint, data = {}) {

--- a/scripts/v2/scripts.js
+++ b/scripts/v2/scripts.js
@@ -17,9 +17,6 @@
  * @param {Object} data additional data for RUM sample
  */
 
-// eslint-disable-next-line
-if (!navigator.sendBeacon) { var data = JSON.stringify({ referer: window.location.href, checkpoint: 'unsupported', weight: 1 }); var img = new Image(); img.src = 'https://rum.hlx3.page/.rum/1?data='+data; document.appendChild(img); }
-
 // eslint-disable-next-line import/prefer-default-export
 function sampleRUM(checkpoint, data = {}) {
   try {

--- a/scripts/v2/scripts.js
+++ b/scripts/v2/scripts.js
@@ -35,7 +35,7 @@ function sampleRUM(checkpoint, data = {}) {
     const { random, weight, id } = window.hlx.rum;
     if (random && (random * weight < 1)) {
       // eslint-disable-next-line object-curly-newline
-      const body = JSON.stringify({ weight, id, referer: window.location.href, generation: 'blog-gen1', checkpoint, ...data });
+      const body = JSON.stringify({ weight, id, referer: window.location.href, generation: 'blog-gen2', checkpoint, ...data });
       const url = `https://rum.hlx3.page/.rum/${weight}`;
       // eslint-disable-next-line no-unused-expressions
       navigator.sendBeacon(url, body); // we should probably use XHR instead of fetch
@@ -325,10 +325,14 @@ handleLCPPerType[window.blog.TYPE.POST].computeLCPCandidate = () => {
     if ($lcpCandidate.complete) {
       postLCP();
     } else {
-      $lcpCandidate.addEventListener('load', () => {
+      $lcpCandidate.addEventListener('load', function lcpLoad() {
+        $lcpCandidate.removeEventListener('load', lcpLoad);
+        // console.log('removing event listener after load');
         postLCP();
       });
-      $lcpCandidate.addEventListener('error', () => {
+      $lcpCandidate.addEventListener('error', function lcpError() {
+        $lcpCandidate.removeEventListener('error', lcpError);
+        // console.log('removing event listener after error');
         postLCP();
       });
     }


### PR DESCRIPTION
https://microfunnel--theblog--adobe.hlx.page/?rum=on

i had to move the code for the old browser instrumentation into `head.html` .  i am not sure what to do about that but it seems that IE etc. don't even make it through the parsing of `scripts.js` it seems that there is no good path avoid the parsing issues, but if someone has a good idea i am very open to any idea...