### PR TITLE
feat: add additional analytics

### DIFF
--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -123,10 +123,28 @@ function setMarTechContext() {
  */
 
 function setDigitalData() {
+  // creates a string from the categories & products for analytics
+  // example: "Category: #AdobeForAll | Category: Adobe Life | Product: Photoshop"
+  const getPageFilterInfo = () => {
+    let pageFilterInfo = "";
+    const categories = window.blog.topics || [];
+    const products = window.blog.products || [];
+    categories.forEach(categories => {
+      pageFilterInfo += `Category: ${categories} | `;
+    })
+    products.forEach(product => {
+      pageFilterInfo += `Product: ${product} | `;
+    })
+    // remove " | " from the end of the string
+    return pageFilterInfo.replace(/ \| $/m, "");
+  }
+
   var langMap={'en': 'en-US'};
   var lang=window.blog.language;
   if (langMap[lang]) lang=langMap[lang];
   digitalData._set('page.pageInfo.language', lang);
+  digitalData._set('page.pageInfo.siteSection', 'blog.adobe.com');
+  digitalData._set('page.pageInfo.attributes.pageFilterInfo', getPageFilterInfo());
 }
 
 setMarTechContext();

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -128,8 +128,8 @@ function setDigitalData() {
   // example: "Category: #AdobeForAll | Category: Adobe Life | Product: Photoshop"
   const getPageFilterInfo = () => {
     let pageFilterInfo = "";
-    const categories = window.blog.topics || [];
-    const products = window.blog.products || [];
+    const categories = window.blog.allTopics || [];
+    const products = window.blog.allProducts || [];
     categories.forEach(categories => {
       pageFilterInfo += `Category: ${categories} | `;
     })

--- a/scripts/martech.js
+++ b/scripts/martech.js
@@ -106,7 +106,8 @@ function setMarTechContext() {
     adobe: {
       launch: {
         property: 'global',
-        environment: env  // “production” for prod/live site or “stage” for qa/staging site
+        environment: env,  // “production” for prod/live site or “stage” for qa/staging site
+        controlPageLoad: true  // if the pageload needs to be controlled by dev team then value needs to be true
       },
       analytics: {
         additionalAccounts: accounts // additional report suites to send data to “,” separated  Ex: 'RS1,RS2'
@@ -147,6 +148,20 @@ function setDigitalData() {
   digitalData._set('page.pageInfo.attributes.pageFilterInfo', getPageFilterInfo());
 }
 
+/**
+ * tracks the initial page load
+ */
+function trackPageLoad() {
+  if (!digitalData || !_satellite) {
+    return;
+  }
+
+  //pageload for initial pageload (For regular tracking of pageload hits)
+  _satellite.track('pageload', {
+    digitalData: digitalData._snapshot()
+  });
+}
+
 setMarTechContext();
 
 window.targetGlobalSettings = {
@@ -155,6 +170,7 @@ window.targetGlobalSettings = {
 
 loadScript('https://www.adobe.com/marketingtech/main.min.js', () => {
   setDigitalData();
+  trackPageLoad();
 });
 
 loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.js').id = 'feds-script';


### PR DESCRIPTION
## Description

Adds additional analytics data 
- `digitalData.page.pageInfo.siteSection: blog.adobe.com`
- `digitalData.page.pageInfo.attributes.pageFilterInfo: "Category: #AdobeForAll | Category: Adobe Life | Product: Photoshop"` (example string, products&categories based on raw topics and products from the source document)

... The [Analytics specification](https://wiki.corp.adobe.com/display/marketingtech/Blogs.adobe.com+-+DataLayer+Specification) mention to add a call to track the `pageload` specifically, but happens automagically already and a second call does nothing.

## Related Issue
- [Jira Issue](https://jira.corp.adobe.com/browse/MWPW-97131)
- [Analytics specification](https://wiki.corp.adobe.com/display/marketingtech/Blogs.adobe.com+-+DataLayer+Specification)

## Motivation and Context

Adds additional analytics 

## How Has This Been Tested?

Verified locally that the new properties are added to the `digitalData` object and sent along on the initial `pageLoad` analytics call

## Screenshots (if appropriate):

![localhost](https://user-images.githubusercontent.com/39759830/134511429-13260d12-116a-4b59-a998-b93756f70d6c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
